### PR TITLE
add image liquid tag

### DIFF
--- a/_plugins/image.rb
+++ b/_plugins/image.rb
@@ -1,0 +1,22 @@
+class Image < Liquid::Tag
+  SYNTAX = /^\s*([^\s]+)(\s+(\d+)\s+(\d+)\s*)?/
+  attr_reader :src
+
+  def initialize(tagName, markup, tokens)
+    super
+
+    if markup =~ SYNTAX
+      @src = $1
+    else
+      raise "No Image provided in the \"image\" tag"
+    end
+  end
+
+  def render(context)
+    %{<a href="#{src}" class="fancybox" rel="gallery">
+        <img src="#{src}" />
+      </a>}
+  end
+
+  Liquid::Template.register_tag "image", self
+end


### PR DESCRIPTION
How to use:
just add this line in any .markdown file
```
{% image /assets/images/posts/2017-03-31-friends/2017-03-11_14-56-40_993.jpg %}
```

link to the original:
http://stackoverflow.com/questions/10529859/how-to-include-video-in-jekyll-markdown-blog